### PR TITLE
#12: EnhancedPropertiesInFileOrResources should not throw an exception if the file in the file-system does not exist

### DIFF
--- a/src/main/java/de/felixsfd/EnhancedProperties/EnhancedPropertiesInFileOrResources.java
+++ b/src/main/java/de/felixsfd/EnhancedProperties/EnhancedPropertiesInFileOrResources.java
@@ -27,6 +27,7 @@ import de.felixsfd.EnhancedProperties.core.SortedProperties;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
@@ -46,7 +47,16 @@ public abstract class EnhancedPropertiesInFileOrResources extends EnhancedWritea
 
 
   /**
-   * Constructor with paths to both files
+   * <p>
+   *   Constructor with paths to both files.
+   * </p>
+   * <p>
+   *   <b>Note:</b> Only if the preferred location is
+   *   {@link de.felixsfd.EnhancedProperties.annotations.ReadRule.Location#FILE},
+   *   the file does not need to exist.<br>
+   *   If the preferred location is {@link de.felixsfd.EnhancedProperties.annotations.ReadRule.Location#RESOURCES},
+   *   the file has to exists because it would contain the default values.
+   * </p>
    * @param filePath Path to properties file in file-system
    * @param resourcesPath Path to properties file in resources
    * @throws IOException if one of the files can't be read.
@@ -55,7 +65,19 @@ public abstract class EnhancedPropertiesInFileOrResources extends EnhancedWritea
     this.filePath = filePath;
     this.resourcesPath = resourcesPath;
 
-    propertiesFile = EnhancedPropertiesInFile.readFromFiles(filePath);
+    SortedProperties newFileProperties;
+    try {
+       newFileProperties = EnhancedPropertiesInFile.readFromFiles(filePath);
+    } catch (FileNotFoundException e) {
+      //File not found, but if the preferred location is FILE, the application can still fall back to resources
+      if (getReadRule() != ReadRule.Location.FILE) {
+        throw e;
+      }
+
+      newFileProperties = new SortedProperties();
+    }
+    propertiesFile = newFileProperties;
+
     propertiesResources = EnhancedPropertiesInResources.readFromResources(resourcesPath);
   } // EnhancedPropertiesInFileOrResources
 

--- a/src/test/java/de/felixsfd/EnhancedProperties/EnhancedPropertiesInFileOrResourcesTest.java
+++ b/src/test/java/de/felixsfd/EnhancedProperties/EnhancedPropertiesInFileOrResourcesTest.java
@@ -28,7 +28,10 @@ import de.felixsfd.EnhancedProperties.testProperties.TestPropertiesResourcesFirs
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class EnhancedPropertiesInFileOrResourcesTest extends EnhancedWriteablePropertiesTest {
   public static final String FILE_PATH = "src/test/resources/test.properties";
@@ -74,5 +77,41 @@ public class EnhancedPropertiesInFileOrResourcesTest extends EnhancedWriteablePr
       Assert.fail();
     }
     super.setValues();
+  }
+
+
+  @Test
+  public void fileInFileSystemDoesNotExist() throws IOException {
+    System.out.println("Renaming test.properties, so the application will not find it");
+    Files.move(Paths.get(FILE_PATH), Paths.get(FILE_PATH + ".gone"));
+
+    try {
+      writeableProperties = new TestPropertiesFileFirst();
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+      Assert.fail("The file was not found, but the @ReadRule is preferredLocation = FILE");
+    } finally {
+      System.out.println("Move file back");
+      Files.move(Paths.get(FILE_PATH + ".gone"), Paths.get(FILE_PATH));
+    }
+  }
+
+
+  @Test
+  public void fileInFileSystemDoesNotExist2() throws IOException {
+    System.out.println("Renaming test.properties, so the application will not find it");
+    Files.move(Paths.get(FILE_PATH), Paths.get(FILE_PATH + ".gone"));
+
+    try {
+      writeableProperties = new TestPropertiesResourcesFirst();
+
+      Assert.fail("No exception was thrown, although the @ReadRule is preferredLocation = RESOURCES" +
+        " and the file in file-system does not exist.");
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+    } finally {
+      System.out.println("Move file back");
+      Files.move(Paths.get(FILE_PATH + ".gone"), Paths.get(FILE_PATH));
+    }
   }
 }


### PR DESCRIPTION
If the preferred location is `FILE`, the file in file system does not need to exist, since the library can fall back to the default values stored in the resources.

If the preferred location is `RESOURCES`, the file in file system has to exists, because it would contain the default values

---

fixes #12 